### PR TITLE
Add handling of Dwolla::RequestException

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ end
 The :scope param is optional.
 
 The default :scope is 'accountinfofull'. It is necessary in order to grab the uid and detailed info for user.
+
+## Exception Handling
+
+If the Dwolla library raises a `Dwolla::RequestException`, that will be wrapped and re-raised as a `OmniAuth::Strategies::OAuth2::CallbackError`.  The OmniAuth OAuth2 library will, in turn, treat that as a failure due to invalid credentials, passing the `CallbackError` through Rack's middleware chain.
+
+Note that the `Devise::OmniauthCallbacksController` provides a good example of handling this scenario.

--- a/lib/omniauth/strategies/dwolla.rb
+++ b/lib/omniauth/strategies/dwolla.rb
@@ -34,6 +34,8 @@ module OmniAuth
       private
         def user
           @user ||= ::Dwolla::User.me(access_token.token).fetch
+        rescue ::Dwolla::RequestException => e
+          raise CallbackError.new(e, e.message)
         end
 
         def prune!(hash)


### PR DESCRIPTION
By wrapping and re-raising the `Dwolla::RequestException` as a `CallbackException`, OmniAuth OAuth2 handles it well (as an 'invalid credentials' failure) and allows the app's authentication/authorization engine to process as needed.

For example, in the case of Devise, the default behavior is to fail user authentication.  This can easily be adjusted based on the wrapped exception to, for example, let the user know that Dwolla payment permission was not received.  That is, **both** authentication and authorization can be handled. 

Without this change, the original `Dwolla::RequestException` is passed up the chain.  For OAuth-based applications, the exception is never handled in the OAuth layer.  In the case of Devise, this means the exception causes the application to have an un-handled error, rather than refusing authentication as one would expect.
