### PR TITLE
Allow sandbox mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ scope permissions for full user info, send and request transactions:
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :dwolla, ENV['DWOLLA_KEY'], ENV['DWOLLA_SECRET'], 
   :scope                  => 'accountinfofull|send|request',
-  :provider_ignores_state => true,
   :client_options => {:site => 'https://uat.dwolla.com'}
 end
 ```

--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ scope permissions for full user info, send and request transactions:
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :dwolla, ENV['DWOLLA_KEY'], ENV['DWOLLA_SECRET'], 
   :scope                  => 'accountinfofull|send|request',
-  :provider_ignores_state => true
+  :provider_ignores_state => true,
+  :client_options => {:site => 'https://uat.dwolla.com'}
 end
 ```
 
-The `:scope` param is optional.
+The `:client_options` param is optional. The default :site is 'https://www.dwolla.com'.
 
-The default :scope is 'accountinfofull'. 
-It is necessary in order to grab the uid and detailed info for user.
+The `:scope` param is optional. The default :scope is 'accountinfofull'. 
+
+It is necessary in order to grab the detailed info for user.
 
 The extra hash will include:
 ```json
@@ -50,16 +52,6 @@ The extra hash will include:
     }
 ```
 
-## Exception Handling
-
-If the Dwolla library raises a `Dwolla::RequestException`, 
-that will be wrapped and re-raised as a 
-`OmniAuth::Strategies::OAuth2::CallbackError`.  The OmniAuth OAuth2 
-library will, in turn, treat that as a failure due to invalid 
-credentials, passing the `CallbackError` through Rack's middleware chain.
-
-Note that the `Devise::OmniauthCallbacksController` provides a 
-good example of handling this scenario.
 
 ## Maintainer's Note
 

--- a/lib/omniauth/strategies/dwolla.rb
+++ b/lib/omniauth/strategies/dwolla.rb
@@ -28,6 +28,14 @@ module OmniAuth
         }
       end
 
+      extra do
+        unless skip_info?
+          { 'raw_info' => user }
+        else
+          {}
+        end
+      end
+
       def authorize_params
         super.tap do |params|
           params[:scope] ||= DEFAULT_SCOPE

--- a/lib/omniauth/strategies/dwolla.rb
+++ b/lib/omniauth/strategies/dwolla.rb
@@ -1,5 +1,4 @@
 require 'omniauth-oauth2'
-require 'dwolla'
 
 module OmniAuth
   module Strategies
@@ -12,21 +11,21 @@ module OmniAuth
         :token_url => '/oauth/v2/token'
       }
       #option :provider_ignores_state, true
-      # setting that has NO effect. 
+      # setting that has NO effect.
       # If anyone can figure a way to make it work
       # PLEASE issue a pull request. -masukomi
 
-      uid { user['Id'] }
+      uid { access_token.params['account_id'] }
 
       info do
-        prune!({
-         'name'      => user['Name'],
-         'latitude'  => user['Latitude'],
-         'longitude' => user['Longitude'],
-         'city'      => user['City'],
-         'state'     => user['State'],
-         'type'      => user['Type']
-     })
+        {
+          'name'      => user['Name'],
+          'latitude'  => user['Latitude'],
+          'longitude' => user['Longitude'],
+          'city'      => user['City'],
+          'state'     => user['State'],
+          'type'      => user['Type']
+        }
       end
 
       def authorize_params
@@ -36,18 +35,10 @@ module OmniAuth
       end
 
       private
-        def user
-          @user ||= ::Dwolla::Users.me(access_token.token)
-        rescue ::Dwolla::DwollaError => e
-          raise CallbackError.new(e, e.message)
-        end
 
-        def prune!(hash)
-          hash.delete_if do |_, value| 
-            prune!(value) if value.is_a?(Hash)
-            value.nil? || (value.respond_to?(:empty?) && value.empty?)
-          end
-        end
-     end
-   end
+      def user
+        @user ||= access_token.get('/oauth/rest/users/').parsed['Response']
+      end
+    end
+  end
 end

--- a/omniauth-dwolla.gemspec
+++ b/omniauth-dwolla.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{OmniAuth strategy for Dwolla.}
   s.description = %q{OmniAuth strategy for Dwolla.}
   s.license     = 'MIT'
-END
   s.rubyforge_project = "omniauth-dwolla"
 
   s.files         = `git ls-files`.split("\n")

--- a/omniauth-dwolla.gemspec
+++ b/omniauth-dwolla.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = %q{OmniAuth strategy for Dwolla.}
   s.license     = 'MIT'
   post_install_string =<<END
-Remember to specify 
+Remember to specify
     :provider_ignores_state => true
 When you set up your Dwolla OmniAuth provider.
 END
@@ -27,7 +27,6 @@ END
 
   s.add_dependency 'omniauth', '~> 1.2'
   s.add_dependency 'omniauth-oauth2', '~> 1.2'
-  s.add_dependency 'dwolla-ruby', '~> 2.5'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.13.0'

--- a/omniauth-dwolla.gemspec
+++ b/omniauth-dwolla.gemspec
@@ -11,13 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{OmniAuth strategy for Dwolla.}
   s.description = %q{OmniAuth strategy for Dwolla.}
   s.license     = 'MIT'
-  post_install_string =<<END
-Remember to specify
-    :provider_ignores_state => true
-When you set up your Dwolla OmniAuth provider.
 END
-  s.post_install_message = post_install_string
-
   s.rubyforge_project = "omniauth-dwolla"
 
   s.files         = `git ls-files`.split("\n")

--- a/spec/omniauth/strategies/dwolla_spec.rb
+++ b/spec/omniauth/strategies/dwolla_spec.rb
@@ -43,20 +43,29 @@ describe OmniAuth::Strategies::Dwolla do
     end
 
     context 'when successful' do
-      it 'sets the correct info based on user' do
-        @access_token.should_receive(:get).with('/oauth/rest/users/').and_return(@access_token_response)
-        # note that the keys are all lowercase
-        # unlike the response that came back from Dwolla
-        expect(subject.info).to eq({ 'name'      => 'Test Name',
-                                     'latitude'  => '123',
-                                     'longitude' => '321',
-                                     'city'      => 'Sample City',
-                                     'state'     => 'TT',
-                                     'type'      => 'Personal' })
-      end
-
       it 'sets the correct uid based on user' do
         subject.uid.should == '12345'
+      end
+
+      describe 'fetching user info' do
+        before do
+          @access_token.should_receive(:get).with('/oauth/rest/users/').and_return(@access_token_response)
+        end
+
+        it 'sets the correct info based on user' do
+          # note that the keys are all lowercase
+          # unlike the response that came back from Dwolla
+          expect(subject.info).to eq({ 'name'      => 'Test Name',
+                                       'latitude'  => '123',
+                                       'longitude' => '321',
+                                       'city'      => 'Sample City',
+                                       'state'     => 'TT',
+                                       'type'      => 'Personal' })
+        end
+
+        it 'sets the extra hash' do
+          subject.extra['raw_info'].should == @dwolla_user
+        end
       end
     end
   end


### PR DESCRIPTION
A patch to respect the use of `:client_options => {:site => 'https://uat.dwolla.com'}` in OmniAuth config.

Removed dwolla-ruby and used the built in #get method instead. This means that the user info is fetched from the same host that the token is retrieved from. Otherwise dwolla-ruby would try to fetch user info from 'www.dwolla.com' even if :client_options[:site] is set to 'uat.dwolla.com'.

A couple of other small changes as per the commit messages.

Cheers!
